### PR TITLE
add API hooks and support for edge shocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ model, results_df, agents_df = run_model(
 )
 ```
 
+`NodeShock.intensity` is normalized to `[0, 1]` and mapped to a synthetic flood
+pseudo-depth of `intensity × 6 m` before the upstream damage curves are applied.
+
 Run the main paper-style 20-seed comparison:
 
 ```bash
@@ -168,7 +171,8 @@ Key configuration blocks:
 - `rp_files`: hazard schedule encoded as
   `RP:START_STEP:END_STEP:HAZARD_TYPE:path`
 - `raster_hazard_events`: structured equivalent of `rp_files`
-- `node_shocks`: explicit direct-damage events with timing, intensity, and coordinates / firm ids
+- `node_shocks`: explicit direct-damage events with timing, normalized intensity
+  (`intensity × 6 m` pseudo-depth), and coordinates / firm ids
 - `lane_shocks`: explicit supplier -> buyer transport throttles
 - `route_shocks`: route-tag transport disruptions keyed by `route_dependencies`
 - `steps`, `start_year`, `steps_per_year`: simulation horizon

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ multiple deployment channels, including:
 - `stockpiling` and `reserved_capacity` as additional experimental strategies
   (`stockpiling` currently means a larger finished-goods buffer, not extra input inventories)
 
-This fork also exposes first-class external shock APIs so callers do not need
-wrapper-owned monkeypatches to model transport disruption:
+The codebase also supports first-class external shock APIs so callers do not 
+need wrapper-owned monkeypatches to model transport disruption:
 
 - `HazardRasterEvent` for GeoTIFF-backed hazard windows
 - `NodeShock` for explicit direct-damage shocks by coordinates or firm ids

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ multiple deployment channels, including:
 - `stockpiling` and `reserved_capacity` as additional experimental strategies
   (`stockpiling` currently means a larger finished-goods buffer, not extra input inventories)
 
+This fork also exposes first-class external shock APIs so callers do not need
+wrapper-owned monkeypatches to model transport disruption:
+
+- `HazardRasterEvent` for GeoTIFF-backed hazard windows
+- `NodeShock` for explicit direct-damage shocks by coordinates or firm ids
+- `LaneShock` for explicit supplier -> buyer transport throttles
+- `RouteShock` for disruptions keyed by topology `route_dependencies`
+- `build_model(...)` and `run_model(...)` for direct Python use from the repo root
+
 ## What the Framework Does
 
 - Samples flood hazard rasters directly from GeoTIFF files at firm locations
@@ -58,6 +67,37 @@ Run a small headless test:
 
 ```bash
 python run_simulation.py --param-file quick_test_parameters.json
+```
+
+Run directly from Python:
+
+```python
+from upstream import NodeShock, RouteShock, run_model
+
+model, results_df, agents_df = run_model(
+    steps=12,
+    num_households=100,
+    num_firms=30,
+    node_shocks=[
+        NodeShock(
+            label="Port outage",
+            hazard_type="PORT_OUTAGE",
+            intensity=0.4,
+            start_step=3,
+            end_step=5,
+            affected_coords=[(32.5, 29.9)],
+        )
+    ],
+    route_shocks=[
+        RouteShock(
+            label="Red Sea bottleneck",
+            route_tag="RED_SEA",
+            intensity=0.5,
+            start_step=3,
+            end_step=8,
+        )
+    ],
+)
 ```
 
 Run the main paper-style 20-seed comparison:
@@ -127,8 +167,13 @@ Key configuration blocks:
 
 - `rp_files`: hazard schedule encoded as
   `RP:START_STEP:END_STEP:HAZARD_TYPE:path`
+- `raster_hazard_events`: structured equivalent of `rp_files`
+- `node_shocks`: explicit direct-damage events with timing, intensity, and coordinates / firm ids
+- `lane_shocks`: explicit supplier -> buyer transport throttles
+- `route_shocks`: route-tag transport disruptions keyed by `route_dependencies`
 - `steps`, `start_year`, `steps_per_year`: simulation horizon
 - `topology`: firm locations and supply-chain edges
+- `damage_functions_path`, `land_boundaries_path`: optional explicit resource paths for environments where the data lives outside `upstream/data`
 - `consumption_ratios`: final-demand allocation over household-purchased sectors
   (`retail`, `wholesale`, `services`; non-final sectors are ignored with a warning)
 - `adaptation`: hazard-conditional firm adaptation settings

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_UPSTREAM_ROOT = Path(__file__).resolve().parent
+if str(_UPSTREAM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_UPSTREAM_ROOT))
+
+from .api import build_model, run_model
+from .shock_inputs import HazardRasterEvent, LaneShock, NodeShock, RouteShock
+
+__all__ = [
+    "build_model",
+    "run_model",
+    "HazardRasterEvent",
+    "NodeShock",
+    "LaneShock",
+    "RouteShock",
+]

--- a/agents.py
+++ b/agents.py
@@ -594,6 +594,9 @@ class FirmAgent(Agent):
         )
 
     def _primary_supplier_shortage_is_hazard_related(self) -> bool:
+        eps = 1e-9
+        if getattr(self, "inbound_route_sales_blocked_this_step", 0.0) > eps:
+            return True
         return any(supplier._has_hazard_disruption_signal() for supplier in self.connected_firms)
 
     def _backup_supplier_count(self) -> int:

--- a/agents.py
+++ b/agents.py
@@ -1272,11 +1272,6 @@ class FirmAgent(Agent):
                 self.inventory_inputs.get(supplier.unique_id, 0.0)
                 for supplier in self.connected_firms
             )
-        primary_inventory_capacity = current_input_units + sum(
-            self.model.available_inventory_for_spot_sales(supplier)
-            for supplier in self.connected_firms
-        )
-
         remaining_inputs_needed = max(0.0, desired_input_units - current_input_units)
         if remaining_inputs_needed > 0 and self.connected_firms and self.INPUT_COEFF > 0:
             suppliers = sorted(
@@ -1291,7 +1286,7 @@ class FirmAgent(Agent):
                     remaining_inputs_needed -= bought
 
         if desired_input_units > 1e-9:
-            physical_shortfall_units = max(0.0, desired_input_units - primary_inventory_capacity)
+            physical_shortfall_units = max(0.0, remaining_inputs_needed)
             physical_shortfall_ratio = min(1.0, max(0.0, physical_shortfall_units / desired_input_units))
         else:
             physical_shortfall_ratio = 0.0
@@ -1365,7 +1360,7 @@ class FirmAgent(Agent):
         if desired_input_units > 1e-9:
             residual_hazard_shortfall_units = max(
                 0.0,
-                max(0.0, desired_input_units - primary_inventory_capacity) - continuity_purchase_coverage,
+                physical_shortfall_units - continuity_purchase_coverage,
             )
             self.supplier_disruption_this_step = (
                 min(1.0, max(0.0, residual_hazard_shortfall_units / desired_input_units))

--- a/api.py
+++ b/api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+
+import pandas as pd
+
+from .model import EconomyModel
+from .shock_inputs import (
+    HazardRasterEvent,
+    LaneShock,
+    NodeShock,
+    RouteShock,
+    normalize_lane_shocks,
+    normalize_node_shocks,
+    normalize_raster_hazard_events,
+    normalize_route_shocks,
+)
+
+
+def build_model(
+    *,
+    width: int | None = None,
+    height: int | None = None,
+    num_households: int = 100,
+    num_firms: int = 20,
+    hazard_events=None,
+    raster_hazard_events: Iterable[HazardRasterEvent | Mapping[str, Any] | tuple[int, int, int, str, str | None]] | None = None,
+    node_shocks: Iterable[NodeShock | Mapping[str, Any]] | None = None,
+    lane_shocks: Iterable[LaneShock | Mapping[str, Any]] | None = None,
+    route_shocks: Iterable[RouteShock | Mapping[str, Any]] | None = None,
+    seed: int | None = None,
+    start_year: int = 0,
+    steps_per_year: int = 4,
+    firm_topology_path: str | None = None,
+    apply_hazard_impacts: bool = True,
+    adaptation_params: dict | None = None,
+    learning_params: dict | None = None,
+    consumption_ratios: dict | None = None,
+    grid_resolution: float = 1.0,
+    household_relocation: bool = False,
+    damage_functions_path: str | None = None,
+    land_boundaries_path: str | None = None,
+) -> EconomyModel:
+    return EconomyModel(
+        width=width,
+        height=height,
+        num_households=num_households,
+        num_firms=num_firms,
+        hazard_events=hazard_events,
+        raster_hazard_events=normalize_raster_hazard_events(raster_hazard_events),
+        node_shocks=normalize_node_shocks(node_shocks),
+        lane_shocks=normalize_lane_shocks(lane_shocks),
+        route_shocks=normalize_route_shocks(route_shocks),
+        seed=seed,
+        start_year=start_year,
+        steps_per_year=steps_per_year,
+        firm_topology_path=firm_topology_path,
+        apply_hazard_impacts=apply_hazard_impacts,
+        adaptation_params=adaptation_params,
+        learning_params=learning_params,
+        consumption_ratios=consumption_ratios,
+        grid_resolution=grid_resolution,
+        household_relocation=household_relocation,
+        damage_functions_path=damage_functions_path,
+        land_boundaries_path=land_boundaries_path,
+    )
+
+
+def run_model(
+    *,
+    steps: int,
+    **model_kwargs,
+) -> tuple[EconomyModel, pd.DataFrame, pd.DataFrame]:
+    model = build_model(**model_kwargs)
+    for _ in range(int(steps)):
+        model.step()
+    results_df = model.results_to_dataframe()
+    agents_df = model.datacollector.get_agent_vars_dataframe().reset_index()
+    agents_df.rename(columns={"level_0": "Step", "level_1": "AgentID"}, inplace=True, errors="ignore")
+    return model, results_df, agents_df

--- a/damage_functions.py
+++ b/damage_functions.py
@@ -18,8 +18,18 @@ import numpy as np
 import pandas as pd
 
 
+def _resolve_default_damage_functions_path() -> Path:
+    local_path = Path(__file__).parent / "data" / "global_flood_depth_damage_functions.xlsx"
+    if local_path.exists():
+        return local_path
+    repo_path = Path(__file__).resolve().parents[1] / "data" / "global_flood_depth_damage_functions.xlsx"
+    if repo_path.exists():
+        return repo_path
+    return local_path
+
+
 # Default path to the JRC damage functions Excel file
-DEFAULT_DAMAGE_FUNCTIONS_PATH = Path(__file__).parent / "data" / "global_flood_depth_damage_functions.xlsx"
+DEFAULT_DAMAGE_FUNCTIONS_PATH = _resolve_default_damage_functions_path()
 
 # Mapping from model sectors to JRC damage classes
 SECTOR_TO_JRC_CLASS = {
@@ -252,16 +262,19 @@ class JRCDamageFunctions:
         return list(REGION_COLUMNS.keys())
 
 
-# Global instance for convenience (lazy loaded)
-_global_damage_functions: Optional[JRCDamageFunctions] = None
+# Global instances for convenience (lazy loaded) keyed by resolved path
+_global_damage_functions: Dict[Path, JRCDamageFunctions] = {}
 
 
-def get_damage_functions() -> JRCDamageFunctions:
-    """Get the global JRCDamageFunctions instance (lazy loaded)."""
-    global _global_damage_functions
-    if _global_damage_functions is None:
-        _global_damage_functions = JRCDamageFunctions()
-    return _global_damage_functions
+def get_damage_functions(excel_path: Optional[Path | str] = None) -> JRCDamageFunctions:
+    """Get a cached JRCDamageFunctions instance for the requested workbook."""
+    resolved_path = Path(excel_path) if excel_path is not None else DEFAULT_DAMAGE_FUNCTIONS_PATH
+    resolved_path = resolved_path.expanduser().resolve()
+    cached = _global_damage_functions.get(resolved_path)
+    if cached is None:
+        cached = JRCDamageFunctions(excel_path=resolved_path)
+        _global_damage_functions[resolved_path] = cached
+    return cached
 
 
 def calc_damage_fraction(

--- a/hazard_utils.py
+++ b/hazard_utils.py
@@ -16,6 +16,9 @@ import rasterio
 Coords = Tuple[int, int]
 HazardEventSpec = Tuple[int, int, int, str, str | None]
 
+_DEPTH_SCALE: float = 6.0
+_DETERMINISTIC_FREQUENCY: float = 1e6
+
 
 class LazyHazard:
     """Memory-efficient hazard that samples from GeoTIFF files on-demand.
@@ -130,6 +133,62 @@ class LazyHazard:
             intensities[i, :] = self.sample_at_coords(coords, i)
 
         return intensities
+
+
+class SyntheticHazard:
+    """Point-driven hazard matching the ``LazyHazard`` sampling interface."""
+
+    def __init__(
+        self,
+        affected_coords: Sequence[Tuple[float, float]],
+        intensity: float,
+        haz_type: str = "SYNTHETIC",
+        radius_deg: float = 0.5,
+        return_period: float | None = None,
+    ) -> None:
+        self.haz_type = haz_type
+        self._affected = np.array(list(affected_coords), dtype=np.float64)
+        self._pseudo_depth = float(intensity) * _DEPTH_SCALE
+        self._radius_deg = float(radius_deg)
+
+        if return_period is None or return_period <= 0:
+            self.frequency = np.array([_DETERMINISTIC_FREQUENCY], dtype=np.float64)
+        else:
+            self.frequency = np.array([1.0 / float(return_period)], dtype=np.float64)
+
+        self.return_periods: List[int] = [
+            max(1, int(return_period)) if return_period else 1
+        ]
+
+    @property
+    def n_events(self) -> int:
+        return 1
+
+    def sample_at_coords(
+        self,
+        coords: List[Tuple[float, float]],
+        event_idx: int,
+    ) -> np.ndarray:
+        if event_idx != 0:
+            raise IndexError(f"SyntheticHazard has only 1 event; got event_idx={event_idx}")
+
+        result = np.zeros(len(coords), dtype=np.float64)
+        if len(self._affected) == 0:
+            return result
+
+        query = np.array(coords, dtype=np.float64)
+        for i in range(len(query)):
+            diffs = self._affected - query[i]
+            min_dist = float(np.min(np.hypot(diffs[:, 0], diffs[:, 1])))
+            if min_dist <= self._radius_deg:
+                result[i] = self._pseudo_depth
+        return result
+
+    def sample_all_events(
+        self,
+        coords: List[Tuple[float, float]],
+    ) -> np.ndarray:
+        return self.sample_at_coords(coords, 0).reshape(1, -1)
 
 
 def parse_hazard_event_specs(rp_files: list[str] | str | None) -> list[HazardEventSpec]:

--- a/hazard_utils.py
+++ b/hazard_utils.py
@@ -136,7 +136,12 @@ class LazyHazard:
 
 
 class SyntheticHazard:
-    """Point-driven hazard matching the ``LazyHazard`` sampling interface."""
+    """Point-driven hazard matching the ``LazyHazard`` sampling interface.
+
+    Synthetic node shocks use a normalized intensity in ``[0, 1]``. That value
+    is mapped to a pseudo-depth via ``intensity * 6 m`` so the resulting damage
+    is evaluated through the same flood damage curves used for raster hazards.
+    """
 
     def __init__(
         self,

--- a/model.py
+++ b/model.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections import defaultdict
+import math
+import json
 from pathlib import Path
-from typing import Dict, List, Tuple, Iterable
+from typing import Dict, List, Tuple, Iterable, Any
 import warnings
 
 import numpy as np
@@ -14,11 +16,56 @@ from mesa import Model
 from mesa.datacollection import DataCollector
 from mesa.space import MultiGrid
 
-from agents import FirmAgent, HouseholdAgent
-from hazard_utils import lazy_hazard_from_geotiffs, LazyHazard
-from damage_functions import get_damage_functions, get_region_from_coords
+try:  # pragma: no cover - package import path
+    from .agents import FirmAgent, HouseholdAgent
+    from .hazard_utils import lazy_hazard_from_geotiffs, LazyHazard, SyntheticHazard
+    from .damage_functions import get_damage_functions, get_region_from_coords
+    from .shock_inputs import (
+        HazardRasterEvent,
+        LaneShock,
+        NodeShock,
+        RouteShock,
+        normalize_lane_shocks,
+        normalize_node_shocks,
+        normalize_raster_hazard_events,
+        normalize_route_shocks,
+    )
+    from .transport_runtime import (
+        dedupe_pairs,
+        inbound_route_exposure_ratio,
+        make_transport_patch,
+        route_exposure_ratio,
+    )
+except ImportError:  # pragma: no cover - flat script import path
+    from agents import FirmAgent, HouseholdAgent
+    from hazard_utils import lazy_hazard_from_geotiffs, LazyHazard, SyntheticHazard
+    from damage_functions import get_damage_functions, get_region_from_coords
+    from shock_inputs import (
+        HazardRasterEvent,
+        LaneShock,
+        NodeShock,
+        RouteShock,
+        normalize_lane_shocks,
+        normalize_node_shocks,
+        normalize_raster_hazard_events,
+        normalize_route_shocks,
+    )
+    from transport_runtime import (
+        dedupe_pairs,
+        inbound_route_exposure_ratio,
+        make_transport_patch,
+        route_exposure_ratio,
+    )
 
 Coords = Tuple[int, int]
+TransportPairs = List[Tuple[FirmAgent, FirmAgent]]
+ActiveTransportBlock = Tuple[float, TransportPairs]
+
+
+def _lon_between(src_lon: float, dst_lon: float, wp_lon: float) -> bool:
+    span = (dst_lon - src_lon + 540) % 360 - 180
+    wp_offset = (wp_lon - src_lon + 540) % 360 - 180
+    return (0 <= wp_offset <= span) if span >= 0 else (span <= wp_offset <= 0)
 
 
 class EconomyModel(Model):
@@ -45,6 +92,10 @@ class EconomyModel(Model):
         num_firms: int = 20,
         # Iterable of (return_period, start_step, end_step, hazard_type, path) tuples
         hazard_events: Iterable[Tuple[int, int, int, str, str | None]] | None = None,
+        raster_hazard_events: Iterable[HazardRasterEvent | Tuple[int, int, int, str, str | None] | dict[str, Any]] | None = None,
+        node_shocks: Iterable[NodeShock | dict[str, Any]] | None = None,
+        lane_shocks: Iterable[LaneShock | dict[str, Any]] | None = None,
+        route_shocks: Iterable[RouteShock | dict[str, Any]] | None = None,
         seed: int | None = None,
         start_year: int = 0,
         steps_per_year: int = 4,
@@ -55,6 +106,8 @@ class EconomyModel(Model):
         consumption_ratios: dict | None = None,
         grid_resolution: float = 1.0,
         household_relocation: bool = False,
+        damage_functions_path: str | None = None,
+        land_boundaries_path: str | None = None,
     ) -> None:  # noqa: D401
         super().__init__(seed=seed)
 
@@ -115,11 +168,20 @@ class EconomyModel(Model):
         self.start_year: int = start_year
         # Calendar granularity (e.g. 4 → quarterly, 12 → monthly)
         self.steps_per_year: int = steps_per_year
+        self.damage_functions_path = (
+            str(Path(damage_functions_path).expanduser())
+            if damage_functions_path is not None
+            else None
+        )
+        self.land_boundaries_path = (
+            str(Path(land_boundaries_path).expanduser())
+            if land_boundaries_path is not None
+            else None
+        )
 
         # --- Spatial environment & custom topology --- #
         self._firm_topology: dict | None = None
         if firm_topology_path is not None:
-            import json, pathlib
             topo_path = Path(firm_topology_path)
             if not topo_path.exists():
                 raise FileNotFoundError(f"Firm topology JSON not found: {topo_path}")
@@ -128,19 +190,25 @@ class EconomyModel(Model):
             # Override num_firms to match the topology file so downstream
             # components (e.g. dashboards, logging) see the correct value.
             num_firms = len(self._firm_topology.get("firms", []))
+        self._raw_topology: dict = self._firm_topology or {}
 
-        if hazard_events is None:
-            raise ValueError("hazard_events must be provided.")
+        self._raster_hazard_events = normalize_raster_hazard_events(
+            raster_hazard_events,
+            legacy_hazard_events=hazard_events,
+        )
+        self._node_shocks = normalize_node_shocks(node_shocks)
+        self._lane_shocks = normalize_lane_shocks(lane_shocks)
+        self._route_shocks = normalize_route_shocks(route_shocks)
 
         # Group by hazard type while preserving order to keep mapping consistent
         grouped_files: dict[str, list[Tuple[int, str]]] = defaultdict(list)
         grouped_ranges: dict[str, list[Tuple[int, int]]] = defaultdict(list)
 
-        for rp, start, end, htype, path in hazard_events:
-            if path is None:
+        for event in self._raster_hazard_events:
+            if event.path is None:
                 continue
-            grouped_files[htype].append((rp, path))
-            grouped_ranges[htype].append((start, end))
+            grouped_files[event.hazard_type].append((event.return_period, event.path))
+            grouped_ranges[event.hazard_type].append((event.start_step, event.end_step))
 
         # Store mapping of event index -> (start, end) per hazard type
         self._hazard_event_ranges: dict[str, List[Tuple[int, int]]] = dict(grouped_ranges)
@@ -149,13 +217,10 @@ class EconomyModel(Model):
         # This reduces memory from ~4GB to <1MB for global hazard datasets
         self.hazards: dict[str, LazyHazard] = {}
 
-        first_haz = None
         for htype, grp in grouped_files.items():
             haz, _, _ = lazy_hazard_from_geotiffs(grp, haz_type=htype)
             # Store lazy hazard that samples on-demand
             self.hazards[htype] = haz
-            if first_haz is None:
-                first_haz = haz
 
         # Agent grid resolution in degrees per cell (e.g., 1.0, 0.5, 0.25)
         # This is decoupled from the hazard raster resolution.
@@ -337,6 +402,7 @@ class EconomyModel(Model):
                 "ever_indirectly_disrupted_before_direct_hit": lambda a: getattr(a, "ever_indirectly_disrupted_before_direct_hit", np.nan),
             },
         )
+        self._install_transport_reporters()
 
         # ---------------- Land mask to avoid placing agents in the ocean ---------------- #
         self.land_coordinates: List[Coords] = self._load_or_compute_land_coordinates()
@@ -360,6 +426,23 @@ class EconomyModel(Model):
 
         # Populate agent caches after all agents created
         self._rebuild_agent_caches()
+        self._topology_id_to_agent: Dict[int, FirmAgent] = {
+            int(agent.unique_id): agent for agent in self._firms
+        }
+        self._primary_supplier_pairs: set[tuple[int, int]] = {
+            (int(supplier.unique_id), int(buyer.unique_id))
+            for buyer in self._firms
+            for supplier in getattr(buyer, "connected_firms", [])
+            if supplier is not None
+        }
+        self._initialize_transport_route_metrics()
+        self._register_node_shocks()
+        self._precomputed_route_transport_edges: List[Tuple[RouteShock, List[Tuple[FirmAgent, FirmAgent]]]] = []
+        self._precomputed_lane_transport_edges: List[Tuple[LaneShock, List[Tuple[FirmAgent, FirmAgent]]]] = []
+        self._build_route_transport_maps()
+        self._build_lane_transport_maps()
+        self._precomputed_transport_edges = self._precomputed_route_transport_edges
+        self._precomputed_link_edges = self._precomputed_lane_transport_edges
 
         # NOTE: With LazyHazard, we no longer need CLIMADA exposures/centroids.
         # Hazard sampling is done directly from GeoTIFF files at agent locations.
@@ -470,6 +553,12 @@ class EconomyModel(Model):
                 separators=(",", ":"),
                 ensure_ascii=True,
             ),
+            "DamageFunctionsPath": self.damage_functions_path or "",
+            "LandBoundariesPath": self.land_boundaries_path or "",
+            "RasterHazardEventCount": int(len(self._raster_hazard_events)),
+            "NodeShockCount": int(len(self._node_shocks)),
+            "LaneShockCount": int(len(self._lane_shocks)),
+            "RouteShockCount": int(len(self._route_shocks)),
         }
 
     def total_money(self) -> float:
@@ -723,6 +812,302 @@ class EconomyModel(Model):
             )
             return
 
+    def _register_node_shocks(self) -> None:
+        """Resolve node shocks to coordinates and register them as synthetic hazards."""
+        if not self._node_shocks:
+            return
+
+        for shock in self._node_shocks:
+            affected_coords = list(shock.affected_coords)
+            if shock.firm_ids:
+                for firm_id in shock.firm_ids:
+                    firm = self._topology_id_to_agent.get(int(firm_id))
+                    if firm is None or firm.pos is None:
+                        warnings.warn(
+                            f"NodeShock '{shock.label}' references unknown firm id {firm_id} — skipping.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+                        continue
+                    x, y = firm.pos
+                    affected_coords.append((float(self.lon_vals[x]), float(self.lat_vals[y])))
+
+            if not affected_coords:
+                warnings.warn(
+                    f"NodeShock '{shock.label}' resolved no coordinates — skipping.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                continue
+
+            haz = SyntheticHazard(
+                affected_coords=affected_coords,
+                intensity=shock.intensity,
+                haz_type=shock.hazard_type,
+                radius_deg=shock.radius_deg,
+                return_period=shock.return_period,
+            )
+            haz_key = shock.hazard_type
+            suffix = 0
+            while haz_key in self.hazards:
+                suffix += 1
+                haz_key = f"{shock.hazard_type}_{suffix}"
+            self.hazards[haz_key] = haz
+            self._hazard_event_ranges[haz_key] = [(shock.start_step, shock.end_step)]
+
+    def _build_route_transport_maps(self) -> None:
+        if not self._route_shocks:
+            return
+        topology_firms = self._raw_topology.get("firms", [])
+        topology_edges = self._raw_topology.get("edges", [])
+        for shock in self._route_shocks:
+            pairs = self._resolve_route_shock_edges(shock, topology_firms, topology_edges)
+            self._precomputed_route_transport_edges.append((shock, pairs))
+            if not pairs:
+                warnings.warn(
+                    f"RouteShock '{shock.label}' (tag: {shock.route_tag}) matched no supply edges in the topology.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+    def _build_lane_transport_maps(self) -> None:
+        if not self._lane_shocks:
+            return
+        for shock in self._lane_shocks:
+            pairs = self._resolve_lane_shock_edges(shock)
+            self._precomputed_lane_transport_edges.append((shock, pairs))
+            if not pairs:
+                warnings.warn(
+                    f"LaneShock '{shock.label}' matched no primary supplier edge in the instantiated topology.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+    def _resolve_route_shock_edges(
+        self,
+        shock: RouteShock,
+        topology_firms: list,
+        topology_edges: list,
+    ) -> TransportPairs:
+        firm_lookup: Dict[int, dict] = {int(f["id"]): f for f in topology_firms}
+        exposed_ids = {
+            int(f["id"])
+            for f in topology_firms
+            if shock.route_tag in f.get("route_dependencies", [])
+        }
+        if not exposed_ids:
+            return []
+
+        pairs: TransportPairs = []
+
+        if shock.waypoint_lon is not None and topology_edges:
+            for edge in topology_edges:
+                dst_id = int(edge["dst"])
+                if dst_id not in exposed_ids:
+                    continue
+                src_id = int(edge["src"])
+                src_firm = firm_lookup.get(src_id)
+                dst_firm = firm_lookup.get(dst_id)
+                if not src_firm or not dst_firm:
+                    continue
+                if _lon_between(
+                    float(src_firm["lon"]),
+                    float(dst_firm["lon"]),
+                    float(shock.waypoint_lon),
+                ):
+                    supplier_agent = self._topology_id_to_agent.get(src_id)
+                    buyer_agent = self._topology_id_to_agent.get(dst_id)
+                    if supplier_agent is not None and buyer_agent is not None:
+                        pairs.append((supplier_agent, buyer_agent))
+            if not pairs:
+                warnings.warn(
+                    f"RouteShock '{shock.label}' (tag: {shock.route_tag}) "
+                    f"has waypoint_lon={shock.waypoint_lon} but no topology edges route through it.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return dedupe_pairs(pairs)
+
+        if topology_edges:
+            for edge in topology_edges:
+                dst_id = int(edge["dst"])
+                if dst_id not in exposed_ids:
+                    continue
+                src_id = int(edge["src"])
+                supplier_agent = self._topology_id_to_agent.get(src_id)
+                buyer_agent = self._topology_id_to_agent.get(dst_id)
+                if supplier_agent is not None and buyer_agent is not None:
+                    pairs.append((supplier_agent, buyer_agent))
+            if pairs:
+                return dedupe_pairs(pairs)
+
+        for exposed_id in exposed_ids:
+            buyer_agent = self._topology_id_to_agent.get(exposed_id)
+            if buyer_agent is None:
+                continue
+            for supplier_agent in getattr(buyer_agent, "connected_firms", []):
+                if supplier_agent is not None:
+                    pairs.append((supplier_agent, buyer_agent))
+
+        return dedupe_pairs(pairs)
+
+    def _resolve_lane_shock_edges(self, shock: LaneShock) -> TransportPairs:
+        supplier_agent = self._topology_id_to_agent.get(int(shock.supplier_id))
+        buyer_agent = self._topology_id_to_agent.get(int(shock.buyer_id))
+        if supplier_agent is None or buyer_agent is None:
+            warnings.warn(
+                f"LaneShock '{shock.label}' references unknown firm ids "
+                f"(supplier_id={shock.supplier_id}, buyer_id={shock.buyer_id}).",
+                UserWarning,
+                stacklevel=2,
+            )
+            return []
+        if (int(shock.supplier_id), int(shock.buyer_id)) not in self._primary_supplier_pairs:
+            warnings.warn(
+                f"LaneShock '{shock.label}' lane "
+                f"(supplier_id={shock.supplier_id}, buyer_id={shock.buyer_id}) "
+                "is not an active primary supplier relationship in this topology.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return []
+        return [(supplier_agent, buyer_agent)]
+
+    def _initialize_transport_route_metrics(self) -> None:
+        for firm in self._firms:
+            firm.route_sales_attempted_this_step = 0.0
+            firm.route_sales_blocked_this_step = 0.0
+            firm.route_revenue_attempted_this_step = 0.0
+            firm.route_revenue_blocked_this_step = 0.0
+            firm.inbound_route_sales_attempted_this_step = 0.0
+            firm.inbound_route_sales_blocked_this_step = 0.0
+            firm.inbound_route_revenue_attempted_this_step = 0.0
+            firm.inbound_route_revenue_blocked_this_step = 0.0
+
+    def _reset_transport_route_metrics(self) -> None:
+        for firm in self._firms:
+            firm.route_sales_attempted_this_step = 0.0
+            firm.route_sales_blocked_this_step = 0.0
+            firm.route_revenue_attempted_this_step = 0.0
+            firm.route_revenue_blocked_this_step = 0.0
+            firm.inbound_route_sales_attempted_this_step = 0.0
+            firm.inbound_route_sales_blocked_this_step = 0.0
+            firm.inbound_route_revenue_attempted_this_step = 0.0
+            firm.inbound_route_revenue_blocked_this_step = 0.0
+
+    def _install_transport_reporters(self) -> None:
+        self.datacollector._new_model_reporter(
+            "Average_Direct_Route_Exposure",
+            lambda m: float(np.mean([route_exposure_ratio(f) for f in m._firms])) if m._firms else 0.0,
+        )
+        self.datacollector._new_model_reporter(
+            "Total_Route_Sales_Attempted",
+            lambda m: sum(getattr(f, "route_sales_attempted_this_step", 0.0) for f in m._firms),
+        )
+        self.datacollector._new_model_reporter(
+            "Total_Route_Sales_Blocked",
+            lambda m: sum(getattr(f, "route_sales_blocked_this_step", 0.0) for f in m._firms),
+        )
+        self.datacollector._new_model_reporter(
+            "Total_Route_Revenue_Attempted",
+            lambda m: sum(getattr(f, "route_revenue_attempted_this_step", 0.0) for f in m._firms),
+        )
+        self.datacollector._new_model_reporter(
+            "Total_Route_Revenue_Blocked",
+            lambda m: sum(getattr(f, "route_revenue_blocked_this_step", 0.0) for f in m._firms),
+        )
+        self.datacollector._new_model_reporter(
+            "Average_Inbound_Route_Exposure",
+            lambda m: float(np.mean([inbound_route_exposure_ratio(f) for f in m._firms])) if m._firms else 0.0,
+        )
+        self.datacollector._new_model_reporter(
+            "Total_Inbound_Route_Revenue_Attempted",
+            lambda m: sum(getattr(f, "inbound_route_revenue_attempted_this_step", 0.0) for f in m._firms),
+        )
+        self.datacollector._new_model_reporter(
+            "Total_Inbound_Route_Revenue_Blocked",
+            lambda m: sum(getattr(f, "inbound_route_revenue_blocked_this_step", 0.0) for f in m._firms),
+        )
+        self.datacollector._new_agent_reporter(
+            "direct_route_exposure",
+            lambda a: route_exposure_ratio(a),
+        )
+        self.datacollector._new_agent_reporter(
+            "inbound_route_exposure",
+            lambda a: inbound_route_exposure_ratio(a),
+        )
+        self.datacollector._new_agent_reporter(
+            "inbound_route_revenue_attempted",
+            lambda a: getattr(a, "inbound_route_revenue_attempted_this_step", np.nan),
+        )
+        self.datacollector._new_agent_reporter(
+            "inbound_route_revenue_blocked",
+            lambda a: getattr(a, "inbound_route_revenue_blocked_this_step", np.nan),
+        )
+        self.datacollector._new_agent_reporter(
+            "route_sales_attempted",
+            lambda a: getattr(a, "route_sales_attempted_this_step", np.nan),
+        )
+        self.datacollector._new_agent_reporter(
+            "route_sales_blocked",
+            lambda a: getattr(a, "route_sales_blocked_this_step", np.nan),
+        )
+        self.datacollector._new_agent_reporter(
+            "route_revenue_attempted",
+            lambda a: getattr(a, "route_revenue_attempted_this_step", np.nan),
+        )
+        self.datacollector._new_agent_reporter(
+            "route_revenue_blocked",
+            lambda a: getattr(a, "route_revenue_blocked_this_step", np.nan),
+        )
+
+    def _active_transport_blocks(self, step_number: int) -> List[ActiveTransportBlock]:
+        active: List[ActiveTransportBlock] = []
+        for shock, pairs in self._precomputed_route_transport_edges:
+            if not (shock.start_step <= step_number <= shock.end_step):
+                continue
+            if shock.return_period is not None:
+                p_fire = 1.0 - math.exp(-1.0 / (float(shock.return_period) * max(self.steps_per_year, 1)))
+                if self.random.random() >= p_fire:
+                    continue
+            active.append((float(shock.intensity), pairs))
+
+        for shock, pairs in self._precomputed_lane_transport_edges:
+            if not (shock.start_step <= step_number <= shock.end_step):
+                continue
+            if shock.blocked_fraction <= 1e-9:
+                continue
+            active.append((float(shock.blocked_fraction), pairs))
+        return active
+
+    def _apply_transport_patches(
+        self,
+        active: List[ActiveTransportBlock],
+    ) -> Dict[int, Tuple[FirmAgent, object]]:
+        if not active:
+            return {}
+
+        supplier_blocks: Dict[int, Tuple[FirmAgent, Dict[int, float]]] = {
+            int(supplier.unique_id): (supplier, {}) for supplier in self._firms
+        }
+        for blocked_fraction, pairs in active:
+            for supplier_agent, buyer_agent in pairs:
+                supplier_id = int(supplier_agent.unique_id)
+                buyer_id = int(buyer_agent.unique_id)
+                current = supplier_blocks[supplier_id][1].get(buyer_id, 0.0)
+                supplier_blocks[supplier_id][1][buyer_id] = max(current, blocked_fraction)
+
+        patches: Dict[int, Tuple[FirmAgent, object]] = {}
+        for supplier_id, (supplier, blocked_buyers) in supplier_blocks.items():
+            original = supplier.sell_goods_to_firm
+            patches[supplier_id] = (supplier, original)
+            supplier.sell_goods_to_firm = make_transport_patch(supplier, original, blocked_buyers)
+        return patches
+
+    def _remove_transport_patches(self, patches: Dict[int, Tuple[FirmAgent, object]]) -> None:
+        for supplier, original in patches.values():
+            supplier.sell_goods_to_firm = original
+
     def _count_reserved_capacity_contracts(self) -> int:
         return sum(
             1
@@ -952,7 +1337,13 @@ class EconomyModel(Model):
         """
 
         try:
-            world = gpd.read_file("./data/ne_110m_admin_0_countries")
+            if self.land_boundaries_path:
+                path = Path(self.land_boundaries_path).expanduser()
+            else:
+                local_path = Path(__file__).resolve().parent / "data" / "ne_110m_admin_0_countries"
+                repo_path = Path(__file__).resolve().parents[1] / "data" / "ne_110m_admin_0_countries"
+                path = local_path if local_path.exists() else repo_path
+            world = gpd.read_file(str(path))
             # Exclude Antarctica so agents are not spawned on that continent
             world = world[world["CONTINENT"] != "Antarctica"]
         except Exception:  # pragma: no cover – dataset missing / offline env
@@ -980,14 +1371,16 @@ class EconomyModel(Model):
     def _load_or_compute_land_coordinates(self) -> List[Coords]:
         """Load cached land coordinates when available, otherwise compute and persist them."""
 
-        cache_key = (len(self.lon_vals), len(self.lat_vals), float(self.grid_resolution))
+        path_tag = self.land_boundaries_path or "__default__"
+        cache_key = (len(self.lon_vals), len(self.lat_vals), float(self.grid_resolution), path_tag)
         cached = self._land_coordinate_cache.get(cache_key)
         if cached is not None:
             return cached.copy()
 
         cache_dir = Path(__file__).resolve().parent / ".cache"
         res_tag = str(self.grid_resolution).replace(".", "p")
-        cache_path = cache_dir / f"land_coordinates_{len(self.lon_vals)}x{len(self.lat_vals)}_{res_tag}.npy"
+        path_suffix = Path(path_tag).name.replace(".", "_").replace("-", "_")
+        cache_path = cache_dir / f"land_coordinates_{len(self.lon_vals)}x{len(self.lat_vals)}_{res_tag}_{path_suffix}.npy"
 
         if cache_path.exists():
             try:
@@ -1166,6 +1559,7 @@ class EconomyModel(Model):
     def step(self) -> None:  # noqa: D401, N802
         """Advance model by one timestep."""
         self.current_step += 1
+        self._reset_transport_route_metrics()
 
         # Firms update resilience decisions before the new hazard state is sampled.
         self._advance_adaptation_learning()
@@ -1198,8 +1592,14 @@ class EconomyModel(Model):
         firms = self._firms.copy()
         # Sort by broad supply-chain tier so upstream sectors replenish before downstream buyers.
         firms.sort(key=self._sector_priority)
-        for firm in firms:
-            firm.step()
+        transport_patches = self._apply_transport_patches(
+            self._active_transport_blocks(self.current_step)
+        )
+        try:
+            for firm in firms:
+                firm.step()
+        finally:
+            self._remove_transport_patches(transport_patches)
 
         # 3. Households consume the goods produced in the current period.
         households = self._households.copy()
@@ -1414,7 +1814,10 @@ class EconomyModel(Model):
                     if not (start <= self.current_step <= end):
                         continue
                 p_annual = haz.frequency[i]
-                p_hit = 1.0 - (1.0 - p_annual) ** (1.0 / max(1, self.steps_per_year))
+                if p_annual >= 1.0:
+                    p_hit = 1.0
+                else:
+                    p_hit = 1.0 - (1.0 - p_annual) ** (1.0 / max(1, self.steps_per_year))
                 if p_hit > 0:
                     active_events.append((i, p_hit))
 
@@ -1447,7 +1850,7 @@ class EconomyModel(Model):
 
         # Apply agent-specific damage using JRC damage functions
         # Get the global damage functions instance (loaded once, cached)
-        damage_funcs = get_damage_functions()
+        damage_funcs = get_damage_functions(self.damage_functions_path)
 
         def apply_damage(ag, is_firm: bool):
             if ag.pos is None:

--- a/model.py
+++ b/model.py
@@ -427,10 +427,13 @@ class EconomyModel(Model):
         # Populate agent caches after all agents created
         self._rebuild_agent_caches()
         self._topology_id_to_agent: Dict[int, FirmAgent] = {
-            int(agent.unique_id): agent for agent in self._firms
+            int(getattr(agent, "topology_id", agent.unique_id)): agent for agent in self._firms
         }
         self._primary_supplier_pairs: set[tuple[int, int]] = {
-            (int(supplier.unique_id), int(buyer.unique_id))
+            (
+                int(getattr(supplier, "topology_id", supplier.unique_id)),
+                int(getattr(buyer, "topology_id", buyer.unique_id)),
+            )
             for buyer in self._firms
             for supplier in getattr(buyer, "connected_firms", [])
             if supplier is not None
@@ -1447,9 +1450,11 @@ class EconomyModel(Model):
                     pos=(x, y),
                     sector=firm.get("sector", "manufacturing"),
                 )
+                # Preserve the external topology identifier for shock lookups.
+                ag.topology_id = int(firm["id"])
                 ag.capital_stock = float(firm.get("capital", 1.0))
                 self.grid.place_agent(ag, (x, y))
-                id_to_agent[firm["id"]] = ag
+                id_to_agent[int(firm["id"])] = ag
 
             # Now we have populated firm_agents_list
             firm_agents_list = list(id_to_agent.values())

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -9,17 +9,43 @@ import subprocess
 import sys
 import numpy as np
 import pandas as pd
-# Import model and agent classes
-from model import EconomyModel
-from agents import FirmAgent, HouseholdAgent
-from ensemble_utils import (
-    ENSEMBLE_STAT_ORDER,
-    METADATA_PREFIX,
-    apply_metadata as apply_ensemble_metadata,
-    build_ensemble_summary as summarize_ensemble,
-    ensemble_seed_metadata as summarize_seed_metadata,
-)
-from hazard_utils import parse_hazard_event_specs
+
+try:  # pragma: no cover - package import path
+    from .model import EconomyModel
+    from .agents import FirmAgent, HouseholdAgent
+    from .ensemble_utils import (
+        ENSEMBLE_STAT_ORDER,
+        METADATA_PREFIX,
+        apply_metadata as apply_ensemble_metadata,
+        build_ensemble_summary as summarize_ensemble,
+        ensemble_seed_metadata as summarize_seed_metadata,
+    )
+    from .hazard_utils import parse_hazard_event_specs
+    from .shock_inputs import (
+        legacy_hazard_event_tuples,
+        normalize_lane_shocks,
+        normalize_node_shocks,
+        normalize_raster_hazard_events,
+        normalize_route_shocks,
+    )
+except ImportError:  # pragma: no cover - flat script import path
+    from model import EconomyModel
+    from agents import FirmAgent, HouseholdAgent
+    from ensemble_utils import (
+        ENSEMBLE_STAT_ORDER,
+        METADATA_PREFIX,
+        apply_metadata as apply_ensemble_metadata,
+        build_ensemble_summary as summarize_ensemble,
+        ensemble_seed_metadata as summarize_seed_metadata,
+    )
+    from hazard_utils import parse_hazard_event_specs
+    from shock_inputs import (
+        legacy_hazard_event_tuples,
+        normalize_lane_shocks,
+        normalize_node_shocks,
+        normalize_raster_hazard_events,
+        normalize_route_shocks,
+    )
 # Runner now expects one or more --rp-file arguments in the form
 # "<RP>:<START_STEP>:<END_STEP>:<TYPE>:<path>"
 
@@ -180,6 +206,25 @@ def _normalized_adaptation_config(adaptation_config: dict | None) -> dict[str, o
     }
 
 
+def _coerce_shock_inputs(
+    *,
+    legacy_rp_files: list[str] | None,
+    raster_hazard_events,
+    node_shocks,
+    lane_shocks,
+    route_shocks,
+):
+    legacy_events = parse_hazard_event_specs(legacy_rp_files) if legacy_rp_files else []
+    raster_events = normalize_raster_hazard_events(
+        raster_hazard_events,
+        legacy_hazard_events=legacy_events,
+    )
+    node_events = normalize_node_shocks(node_shocks)
+    lane_events = normalize_lane_shocks(lane_shocks)
+    route_events = normalize_route_shocks(route_shocks)
+    return raster_events, node_events, lane_events, route_events
+
+
 def _base_metadata(
     *,
     args,
@@ -226,6 +271,8 @@ def _base_metadata(
         f"{METADATA_PREFIX}NumHouseholds": int(args.num_households),
         f"{METADATA_PREFIX}GridResolution": float(args.grid_resolution),
         f"{METADATA_PREFIX}HouseholdRelocation": bool(args.household_relocation),
+        f"{METADATA_PREFIX}DamageFunctionsPath": str(getattr(args, "damage_functions_path", "") or ""),
+        f"{METADATA_PREFIX}LandBoundariesPath": str(getattr(args, "land_boundaries_path", "") or ""),
         f"{METADATA_PREFIX}ConsumptionRatios": _metadata_json(getattr(args, "consumption_ratios", None)),
         f"{METADATA_PREFIX}ParamConsumptionRatios": _metadata_json(param_data.get("consumption_ratios")),
         f"{METADATA_PREFIX}HHConsumptionPropensityIncome": float(HouseholdAgent.CONSUMPTION_PROPENSITY_INCOME),
@@ -304,8 +351,11 @@ def _finalize_agent_results(agent_df: pd.DataFrame, *, scenario_display: str, se
 def _run_single_simulation(
     *,
     args,
-    events,
-    apply_hazards: bool,
+    raster_events,
+    node_shocks,
+    lane_shocks,
+    route_shocks,
+    apply_shocks: bool,
     adaptation_config: dict,
     seed: int,
     scenario_display: str,
@@ -313,9 +363,12 @@ def _run_single_simulation(
     model = EconomyModel(
         num_households=args.num_households,
         num_firms=20,
-        hazard_events=events,
+        raster_hazard_events=raster_events,
+        node_shocks=node_shocks,
+        lane_shocks=lane_shocks,
+        route_shocks=route_shocks,
         seed=seed,
-        apply_hazard_impacts=apply_hazards,
+        apply_hazard_impacts=apply_shocks,
         firm_topology_path=args.topology,
         start_year=args.start_year,
         steps_per_year=args.steps_per_year,
@@ -323,6 +376,8 @@ def _run_single_simulation(
         consumption_ratios=args.consumption_ratios,
         grid_resolution=args.grid_resolution,
         household_relocation=args.household_relocation,
+        damage_functions_path=getattr(args, "damage_functions_path", None),
+        land_boundaries_path=getattr(args, "land_boundaries_path", None),
     )
 
     for _ in range(args.steps):
@@ -418,6 +473,12 @@ def _save_ensemble_plot(summary_df: pd.DataFrame, member_df: pd.DataFrame, outpu
 def main() -> None:  # noqa: D401
     args = _parse()
     param_data: dict = {}
+    args.raster_hazard_events = None
+    args.node_shocks = None
+    args.lane_shocks = None
+    args.route_shocks = None
+    args.damage_functions_path = None
+    args.land_boundaries_path = None
 
     # ---------------- Optional parameter file ---------------------------- #
     if args.param_file:
@@ -469,39 +530,50 @@ def main() -> None:  # noqa: D401
         # 4. Topology path --------------------------------------------------
         if not args.topology and param_data.get("topology"):
             args.topology = str(param_data["topology"])
-        
-        # 5. Adaptation parameters ------------------------------------------
+
+        # 5. Explicit shock sections ----------------------------------------
+        args.raster_hazard_events = param_data.get("raster_hazard_events", None)
+        args.node_shocks = param_data.get("node_shocks", None)
+        args.lane_shocks = param_data.get("lane_shocks", None)
+        args.route_shocks = param_data.get("route_shocks", None)
+
+        # 6. Resource paths -------------------------------------------------
+        if param_data.get("damage_functions_path") is not None:
+            args.damage_functions_path = str(param_data["damage_functions_path"])
+        if param_data.get("land_boundaries_path") is not None:
+            args.land_boundaries_path = str(param_data["land_boundaries_path"])
+
+        # 7. Adaptation parameters ------------------------------------------
         args.adaptation_params = param_data.get("adaptation", param_data.get("learning", {}))
 
-        # 6. Consumption ratios by sector -----------------------------------
+        # 8. Consumption ratios by sector -----------------------------------
         args.consumption_ratios = param_data.get("consumption_ratios", None)
 
-        # 7. Number of households -------------------------------------------
+        # 9. Number of households -------------------------------------------
         args.num_households = int(param_data.get("num_households", 100))
 
-        # 8. Grid resolution (degrees per cell) -----------------------------
+        # 10. Grid resolution (degrees per cell) ----------------------------
         args.grid_resolution = float(param_data.get("grid_resolution", 1.0))
 
-        # 9. Household relocation toggle -------------------------------------
+        # 11. Household relocation toggle -----------------------------------
         args.household_relocation = bool(param_data.get("household_relocation", False))
         if not args.save_agent_ensemble and "save_agent_ensemble" in param_data:
             args.save_agent_ensemble = bool(param_data.get("save_agent_ensemble", False))
         if args.ensemble_plot_stat == "mean" and "ensemble_plot_stat" in param_data:
             args.ensemble_plot_stat = str(param_data.get("ensemble_plot_stat", "mean"))
 
-    # Ensure we have at least one RP spec after merging param file -----------
-    if not args.rp_file:
-        raise SystemExit("No --rp-file entries provided and none found in parameter file.")
+    try:
+        raster_events, node_shocks, lane_shocks, route_shocks = _coerce_shock_inputs(
+            legacy_rp_files=args.rp_file,
+            raster_hazard_events=args.raster_hazard_events,
+            node_shocks=args.node_shocks,
+            lane_shocks=args.lane_shocks,
+            route_shocks=args.route_shocks,
+        )
+    except (TypeError, ValueError) as exc:  # noqa: BLE001
+        raise SystemExit(str(exc)) from exc
 
-    # First, parse the RP files into a list irrespective of --viz so we can
-    # pass them on to a potential Solara dashboard.
-    # Parsed as (return_period, start_step, end_step, hazard_type, path|None)
-    events: list[tuple[int, int, int, str, str | None]] = []
-    if args.rp_file:
-        try:
-            events = parse_hazard_event_specs(args.rp_file)
-        except ValueError as exc:  # noqa: BLE001
-            raise SystemExit(str(exc)) from exc
+    events = legacy_hazard_event_tuples(raster_events)
 
     seed_list = _resolve_seed_list(args)
     if args.viz and len(seed_list) > 1:
@@ -510,6 +582,9 @@ def main() -> None:  # noqa: D401
     # If visualization requested, delegate to Solara which hosts the dashboard
     if args.viz:
         import subprocess, sys, os
+
+        if node_shocks or lane_shocks or route_shocks:
+            raise SystemExit("Visualization currently supports raster_hazard_events only.")
 
         env = os.environ.copy()
         # Pass hazard events to the dashboard so it can build the same model
@@ -552,7 +627,8 @@ def main() -> None:  # noqa: D401
         args.household_relocation = False  # default disabled
 
     # Configure scenario settings
-    apply_hazards = not args.no_hazards
+    has_shock_inputs = bool(raster_events or node_shocks or lane_shocks or route_shocks)
+    apply_hazards = bool(has_shock_inputs and not args.no_hazards)
     disable_adaptation = bool(args.no_adaptation or args.no_learning)
     if disable_adaptation:
         adaptation_config = {**args.adaptation_params, "enabled": False}
@@ -625,8 +701,11 @@ def main() -> None:  # noqa: D401
         for seed in seed_list:
             _, seed_df, seed_agent_df, seed_effective_metadata = _run_single_simulation(
                 args=args,
-                events=events,
-                apply_hazards=apply_hazards,
+                raster_events=raster_events,
+                node_shocks=node_shocks,
+                lane_shocks=lane_shocks,
+                route_shocks=route_shocks,
+                apply_shocks=apply_hazards,
                 adaptation_config=adaptation_config,
                 seed=seed,
                 scenario_display=scenario_display,
@@ -672,8 +751,11 @@ def main() -> None:  # noqa: D401
 
     model, df, agent_df, effective_model_metadata = _run_single_simulation(
         args=args,
-        events=events,
-        apply_hazards=apply_hazards,
+        raster_events=raster_events,
+        node_shocks=node_shocks,
+        lane_shocks=lane_shocks,
+        route_shocks=route_shocks,
+        apply_shocks=apply_hazards,
         adaptation_config=adaptation_config,
         seed=seed_list[0],
         scenario_display=scenario_display,

--- a/shock_inputs.py
+++ b/shock_inputs.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+LegacyHazardEvent = tuple[int, int, int, str, str | None]
+Coords = tuple[float, float]
+
+
+def _coerce_coords(values: Sequence[Sequence[float]] | None) -> tuple[Coords, ...]:
+    if not values:
+        return ()
+    coords: list[Coords] = []
+    for value in values:
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            raise ValueError(f"Each coordinate must be a (lon, lat) pair, got {value!r}")
+        coords.append((float(value[0]), float(value[1])))
+    return tuple(coords)
+
+
+def _coerce_ids(values: Sequence[int] | None) -> tuple[int, ...]:
+    if not values:
+        return ()
+    return tuple(int(value) for value in values)
+
+
+@dataclass(frozen=True)
+class HazardRasterEvent:
+    return_period: int
+    start_step: int
+    end_step: int
+    hazard_type: str
+    path: str | None
+
+    def __post_init__(self) -> None:
+        if self.return_period <= 0:
+            raise ValueError(f"return_period must be positive, got {self.return_period}")
+        if self.start_step > self.end_step:
+            raise ValueError(
+                f"start_step ({self.start_step}) must be <= end_step ({self.end_step})"
+            )
+        if not str(self.hazard_type).strip():
+            raise ValueError("hazard_type must not be empty")
+        if self.path is not None and not str(self.path).strip():
+            raise ValueError("path must be a non-empty string or None")
+
+    @property
+    def haz_type(self) -> str:
+        return self.hazard_type
+
+    def to_legacy_tuple(self) -> LegacyHazardEvent:
+        return (
+            int(self.return_period),
+            int(self.start_step),
+            int(self.end_step),
+            str(self.hazard_type),
+            None if self.path is None else str(self.path),
+        )
+
+    @classmethod
+    def from_legacy_tuple(cls, value: LegacyHazardEvent) -> "HazardRasterEvent":
+        rp, start, end, hazard_type, path = value
+        return cls(
+            return_period=int(rp),
+            start_step=int(start),
+            end_step=int(end),
+            hazard_type=str(hazard_type),
+            path=None if path is None else str(path),
+        )
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "HazardRasterEvent":
+        return cls(
+            return_period=int(value["return_period"]),
+            start_step=int(value["start_step"]),
+            end_step=int(value["end_step"]),
+            hazard_type=str(value.get("hazard_type", value.get("haz_type", "FL"))),
+            path=None if value.get("path") is None else str(value["path"]),
+        )
+
+
+@dataclass(frozen=True)
+class NodeShock:
+    label: str
+    hazard_type: str
+    intensity: float
+    start_step: int
+    end_step: int
+    return_period: float | None = None
+    radius_deg: float = 0.5
+    affected_coords: tuple[Coords, ...] = ()
+    firm_ids: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= float(self.intensity) <= 1.0:
+            raise ValueError(f"intensity must be in [0, 1], got {self.intensity}")
+        if self.start_step > self.end_step:
+            raise ValueError(
+                f"start_step ({self.start_step}) must be <= end_step ({self.end_step})"
+            )
+        if self.return_period is not None and float(self.return_period) <= 0:
+            raise ValueError(f"return_period must be positive, got {self.return_period}")
+        if float(self.radius_deg) < 0:
+            raise ValueError(f"radius_deg must be non-negative, got {self.radius_deg}")
+        if not str(self.hazard_type).strip():
+            raise ValueError("hazard_type must not be empty")
+        if not self.affected_coords and not self.firm_ids:
+            raise ValueError("NodeShock requires affected_coords and/or firm_ids")
+
+    @property
+    def haz_type(self) -> str:
+        return self.hazard_type
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "NodeShock":
+        return cls(
+            label=str(value.get("label", "Node shock")),
+            hazard_type=str(value.get("hazard_type", value.get("haz_type", "CUSTOM_SHOCK"))),
+            intensity=float(value["intensity"]),
+            start_step=int(value["start_step"]),
+            end_step=int(value["end_step"]),
+            return_period=None if value.get("return_period") is None else float(value["return_period"]),
+            radius_deg=float(value.get("radius_deg", 0.5)),
+            affected_coords=_coerce_coords(value.get("affected_coords")),
+            firm_ids=_coerce_ids(value.get("firm_ids")),
+        )
+
+
+@dataclass(frozen=True)
+class LaneShock:
+    label: str
+    supplier_id: int
+    buyer_id: int
+    capacity_fraction: float
+    start_step: int
+    end_step: int
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= float(self.capacity_fraction) <= 1.0:
+            raise ValueError(
+                f"capacity_fraction must be in [0, 1], got {self.capacity_fraction}"
+            )
+        if self.start_step > self.end_step:
+            raise ValueError(
+                f"start_step ({self.start_step}) must be <= end_step ({self.end_step})"
+            )
+
+    @property
+    def blocked_fraction(self) -> float:
+        return 1.0 - float(self.capacity_fraction)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> list["LaneShock"]:
+        label = str(value.get("label", "Lane shock"))
+        capacity_fraction = float(value["capacity_fraction"])
+        start_step = int(value["start_step"])
+        end_step = int(value["end_step"])
+
+        if "supplier_id" in value and "buyer_id" in value:
+            return [
+                cls(
+                    label=label,
+                    supplier_id=int(value["supplier_id"]),
+                    buyer_id=int(value["buyer_id"]),
+                    capacity_fraction=capacity_fraction,
+                    start_step=start_step,
+                    end_step=end_step,
+                )
+            ]
+
+        raw_links = value.get("links")
+        if not raw_links:
+            raise ValueError("Lane shock mapping requires supplier_id/buyer_id or links")
+
+        shocks: list[LaneShock] = []
+        for index, raw_link in enumerate(raw_links, start=1):
+            if not isinstance(raw_link, (list, tuple)) or len(raw_link) != 2:
+                raise ValueError(f"Each lane link must be [supplier_id, buyer_id], got {raw_link!r}")
+            shocks.append(
+                cls(
+                    label=label if len(raw_links) == 1 else f"{label} #{index}",
+                    supplier_id=int(raw_link[0]),
+                    buyer_id=int(raw_link[1]),
+                    capacity_fraction=capacity_fraction,
+                    start_step=start_step,
+                    end_step=end_step,
+                )
+            )
+        return shocks
+
+
+@dataclass(frozen=True)
+class RouteShock:
+    label: str
+    route_tag: str
+    intensity: float
+    start_step: int
+    end_step: int
+    return_period: float | None = None
+    waypoint_lon: float | None = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= float(self.intensity) <= 1.0:
+            raise ValueError(f"intensity must be in [0, 1], got {self.intensity}")
+        if self.start_step > self.end_step:
+            raise ValueError(
+                f"start_step ({self.start_step}) must be <= end_step ({self.end_step})"
+            )
+        if self.return_period is not None and float(self.return_period) <= 0:
+            raise ValueError(f"return_period must be positive, got {self.return_period}")
+        if not str(self.route_tag).strip():
+            raise ValueError("route_tag must not be empty")
+
+    @property
+    def bottleneck_id(self) -> str:
+        return self.route_tag
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "RouteShock":
+        return cls(
+            label=str(value.get("label", "Route shock")),
+            route_tag=str(value.get("route_tag", value.get("bottleneck_id"))),
+            intensity=float(value["intensity"]),
+            start_step=int(value["start_step"]),
+            end_step=int(value["end_step"]),
+            return_period=None if value.get("return_period") is None else float(value["return_period"]),
+            waypoint_lon=None if value.get("waypoint_lon") is None else float(value["waypoint_lon"]),
+        )
+
+
+def normalize_raster_hazard_events(
+    raster_hazard_events: Iterable[HazardRasterEvent | Mapping[str, Any] | LegacyHazardEvent] | None = None,
+    *,
+    legacy_hazard_events: Iterable[LegacyHazardEvent] | None = None,
+) -> list[HazardRasterEvent]:
+    normalized: list[HazardRasterEvent] = []
+    if legacy_hazard_events:
+        normalized.extend(HazardRasterEvent.from_legacy_tuple(value) for value in legacy_hazard_events)
+    if not raster_hazard_events:
+        return normalized
+    for value in raster_hazard_events:
+        if isinstance(value, HazardRasterEvent):
+            normalized.append(value)
+        elif isinstance(value, Mapping):
+            normalized.append(HazardRasterEvent.from_mapping(value))
+        else:
+            normalized.append(HazardRasterEvent.from_legacy_tuple(value))
+    return normalized
+
+
+def normalize_node_shocks(
+    node_shocks: Iterable[NodeShock | Mapping[str, Any]] | None = None,
+) -> list[NodeShock]:
+    if not node_shocks:
+        return []
+    normalized: list[NodeShock] = []
+    for value in node_shocks:
+        if isinstance(value, NodeShock):
+            normalized.append(value)
+        elif isinstance(value, Mapping):
+            normalized.append(NodeShock.from_mapping(value))
+        else:
+            raise TypeError(f"Unsupported node shock value: {value!r}")
+    return normalized
+
+
+def normalize_lane_shocks(
+    lane_shocks: Iterable[LaneShock | Mapping[str, Any]] | None = None,
+) -> list[LaneShock]:
+    if not lane_shocks:
+        return []
+    normalized: list[LaneShock] = []
+    for value in lane_shocks:
+        if isinstance(value, LaneShock):
+            normalized.append(value)
+        elif isinstance(value, Mapping):
+            normalized.extend(LaneShock.from_mapping(value))
+        else:
+            raise TypeError(f"Unsupported lane shock value: {value!r}")
+    return normalized
+
+
+def normalize_route_shocks(
+    route_shocks: Iterable[RouteShock | Mapping[str, Any]] | None = None,
+) -> list[RouteShock]:
+    if not route_shocks:
+        return []
+    normalized: list[RouteShock] = []
+    for value in route_shocks:
+        if isinstance(value, RouteShock):
+            normalized.append(value)
+        elif isinstance(value, Mapping):
+            normalized.append(RouteShock.from_mapping(value))
+        else:
+            raise TypeError(f"Unsupported route shock value: {value!r}")
+    return normalized
+
+
+def legacy_hazard_event_tuples(events: Iterable[HazardRasterEvent]) -> list[LegacyHazardEvent]:
+    return [event.to_legacy_tuple() for event in events]

--- a/shock_inputs.py
+++ b/shock_inputs.py
@@ -82,6 +82,14 @@ class HazardRasterEvent:
 
 @dataclass(frozen=True)
 class NodeShock:
+    """Explicit direct-damage event for coordinates and/or topology firm ids.
+
+    ``intensity`` is normalized to ``[0, 1]`` and mapped to a synthetic flood
+    pseudo-depth of ``intensity * 6 m`` before passing through the upstream
+    damage curves. This keeps node shocks on the same damage-function scale as
+    raster flood inputs.
+    """
+
     label: str
     hazard_type: str
     intensity: float
@@ -218,9 +226,12 @@ class RouteShock:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any]) -> "RouteShock":
+        route_tag = value.get("route_tag", value.get("bottleneck_id"))
+        if route_tag is None or not str(route_tag).strip():
+            raise ValueError("RouteShock requires route_tag or bottleneck_id")
         return cls(
             label=str(value.get("label", "Route shock")),
-            route_tag=str(value.get("route_tag", value.get("bottleneck_id"))),
+            route_tag=str(route_tag),
             intensity=float(value["intensity"]),
             start_step=int(value["start_step"]),
             end_step=int(value["end_step"]),

--- a/tests/test_ensemble_outputs.py
+++ b/tests/test_ensemble_outputs.py
@@ -3,8 +3,19 @@ from types import SimpleNamespace
 
 import pandas as pd
 
-from plot_from_csv_paper import summarize_members_for_plot
-from run_simulation import _base_metadata, _build_ensemble_summary, _resolve_seed_list
+from upstream.plot_from_csv import summarize_members_for_plot
+from upstream.run_simulation import (
+    _base_metadata,
+    _build_ensemble_summary,
+    _coerce_shock_inputs,
+    _resolve_seed_list,
+)
+from upstream.shock_inputs import (
+    HazardRasterEvent,
+    LaneShock,
+    NodeShock,
+    RouteShock,
+)
 
 
 def test_resolve_seed_list_deduplicates_explicit_seeds() -> None:
@@ -104,6 +115,7 @@ def test_base_metadata_matches_model_adaptation_defaults() -> None:
         "min_money_survival": 1.0,
         "observation_radius": 4.0,
         "replacement_frequency": 10,
+        "reorganization_inheritance": "inherit_parent",
         "reserved_capacity_markup_cap": 0.1,
         "reserved_capacity_share": 0.35,
     }
@@ -178,7 +190,131 @@ def test_base_metadata_tracks_param_and_cli_provenance() -> None:
         "min_money_survival": 1.0,
         "observation_radius": 4.0,
         "replacement_frequency": 10,
+        "reorganization_inheritance": "inherit_parent",
         "reserved_capacity_markup_cap": 0.1,
         "reserved_capacity_share": 0.35,
     }
     assert metadata["Meta_RunCommand"]
+
+
+def test_base_metadata_records_explicit_resource_paths() -> None:
+    args = SimpleNamespace(
+        param_file="params.json",
+        topology="topology.json",
+        start_year=2000,
+        steps_per_year=4,
+        steps=40,
+        num_households=1000,
+        grid_resolution=0.25,
+        household_relocation=False,
+        no_hazards=False,
+        no_adaptation=False,
+        no_learning=False,
+        adaptation_strategy=None,
+        adaptation_sensitivity_min=None,
+        adaptation_sensitivity_max=None,
+        consumption_ratios={"retail": 1.0},
+        damage_functions_path="/tmp/damage.xlsx",
+        land_boundaries_path="/tmp/land",
+        save_agent_ensemble=False,
+        ensemble_plot_stat="mean",
+    )
+
+    metadata = _base_metadata(
+        args=args,
+        events=[(10, 1, 40, "FL", "hazard.tif")],
+        apply_hazards=True,
+        adaptation_enabled=False,
+        adaptation_config={},
+        scenario_label="hazard_only",
+        timestamp="20260421_000000",
+        param_data={},
+    )
+
+    assert metadata["Meta_DamageFunctionsPath"] == "/tmp/damage.xlsx"
+    assert metadata["Meta_LandBoundariesPath"] == "/tmp/land"
+
+
+def test_coerce_shock_inputs_normalizes_new_param_sections() -> None:
+    raster_events, node_events, lane_events, route_events = _coerce_shock_inputs(
+        legacy_rp_files=["10:1:2:FL:None"],
+        raster_hazard_events=[
+            {
+                "return_period": 25,
+                "start_step": 3,
+                "end_step": 4,
+                "hazard_type": "EQ",
+                "path": None,
+            }
+        ],
+        node_shocks=[
+            {
+                "label": "Node",
+                "hazard_type": "CUSTOM_NODE",
+                "intensity": 0.6,
+                "start_step": 1,
+                "end_step": 2,
+                "affected_coords": [[10.0, 20.0]],
+            }
+        ],
+        lane_shocks=[
+            {
+                "label": "Lane",
+                "links": [[1, 2], [3, 4]],
+                "capacity_fraction": 0.4,
+                "start_step": 5,
+                "end_step": 6,
+            }
+        ],
+        route_shocks=[
+            {
+                "label": "Route",
+                "route_tag": "TEST_ROUTE",
+                "intensity": 0.5,
+                "start_step": 7,
+                "end_step": 8,
+            }
+        ],
+    )
+
+    assert raster_events == [
+        HazardRasterEvent(return_period=10, start_step=1, end_step=2, hazard_type="FL", path=None),
+        HazardRasterEvent(return_period=25, start_step=3, end_step=4, hazard_type="EQ", path=None),
+    ]
+    assert node_events == [
+        NodeShock(
+            label="Node",
+            hazard_type="CUSTOM_NODE",
+            intensity=0.6,
+            start_step=1,
+            end_step=2,
+            affected_coords=((10.0, 20.0),),
+        )
+    ]
+    assert lane_events == [
+        LaneShock(
+            label="Lane #1",
+            supplier_id=1,
+            buyer_id=2,
+            capacity_fraction=0.4,
+            start_step=5,
+            end_step=6,
+        ),
+        LaneShock(
+            label="Lane #2",
+            supplier_id=3,
+            buyer_id=4,
+            capacity_fraction=0.4,
+            start_step=5,
+            end_step=6,
+        ),
+    ]
+    assert route_events == [
+        RouteShock(
+            label="Route",
+            route_tag="TEST_ROUTE",
+            intensity=0.5,
+            start_step=7,
+            end_step=8,
+        )
+    ]

--- a/tests/test_shock_api.py
+++ b/tests/test_shock_api.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from upstream import (
+    HazardRasterEvent,
+    LaneShock,
+    NodeShock,
+    RouteShock,
+    build_model,
+    run_model,
+)
+from upstream.run_simulation import _coerce_shock_inputs
+from upstream.shock_inputs import normalize_raster_hazard_events
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DAMAGE_FUNCTIONS_PATH = _REPO_ROOT / "data" / "global_flood_depth_damage_functions.xlsx"
+_LAND_BOUNDARIES_PATH = _REPO_ROOT / "data" / "ne_110m_admin_0_countries"
+
+
+def _write_topology(tmp_path: Path, *, route_dependencies: list[str] | None = None) -> str:
+    buyer = {
+        "id": 2,
+        "sector": "manufacturing",
+        "lon": 1.0,
+        "lat": 1.0,
+        "capital": 5.0,
+    }
+    if route_dependencies:
+        buyer["route_dependencies"] = list(route_dependencies)
+
+    topology = {
+        "firms": [
+            {"id": 1, "sector": "commodity", "lon": 0.0, "lat": 0.0, "capital": 5.0},
+            buyer,
+            {"id": 3, "sector": "retail", "lon": 2.0, "lat": 1.0, "capital": 5.0},
+            {"id": 4, "sector": "commodity", "lon": -1.0, "lat": 0.0, "capital": 5.0},
+        ],
+        "edges": [
+            {"src": 1, "dst": 2},
+            {"src": 2, "dst": 3},
+        ],
+    }
+    path = tmp_path / "topology.json"
+    path.write_text(json.dumps(topology))
+    return str(path)
+
+
+def test_package_exports_support_legacy_raster_normalization() -> None:
+    legacy = [(10, 1, 4, "FL", None)]
+    normalized = normalize_raster_hazard_events(legacy_hazard_events=legacy)
+
+    assert normalized == [
+        HazardRasterEvent(
+            return_period=10,
+            start_step=1,
+            end_step=4,
+            hazard_type="FL",
+            path=None,
+        )
+    ]
+
+
+def test_build_model_records_resource_paths_and_shock_counts(tmp_path: Path) -> None:
+    topology_path = _write_topology(tmp_path, route_dependencies=["TEST_ROUTE"])
+
+    model = build_model(
+        num_households=10,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=False,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=7,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+        node_shocks=[
+            NodeShock(
+                label="Node",
+                hazard_type="CUSTOM_NODE",
+                intensity=0.4,
+                start_step=1,
+                end_step=1,
+                affected_coords=((0.0, 0.0),),
+            )
+        ],
+        lane_shocks=[
+            LaneShock(
+                label="Lane",
+                supplier_id=1,
+                buyer_id=2,
+                capacity_fraction=0.3,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+        route_shocks=[
+            RouteShock(
+                label="Route",
+                route_tag="TEST_ROUTE",
+                intensity=0.5,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+    )
+
+    metadata = model.effective_configuration_metadata()
+
+    assert metadata["DamageFunctionsPath"] == str(_DAMAGE_FUNCTIONS_PATH)
+    assert metadata["LandBoundariesPath"] == str(_LAND_BOUNDARIES_PATH)
+    assert metadata["RasterHazardEventCount"] == 0
+    assert metadata["NodeShockCount"] == 1
+    assert metadata["LaneShockCount"] == 1
+    assert metadata["RouteShockCount"] == 1
+
+
+def test_run_model_returns_model_and_agent_frames(tmp_path: Path) -> None:
+    topology_path = _write_topology(tmp_path)
+
+    model, results_df, agents_df = run_model(
+        steps=2,
+        num_households=10,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=False,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=9,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+    )
+
+    assert model.current_step == 2
+    assert len(results_df) == 2
+    assert {"Step", "AgentID"}.issubset(set(agents_df.columns))
+
+
+def test_param_input_normalization_expands_lane_link_lists() -> None:
+    raster_events, node_events, lane_events, route_events = _coerce_shock_inputs(
+        legacy_rp_files=["5:1:2:FL:None"],
+        raster_hazard_events=None,
+        node_shocks=[
+            {
+                "label": "Node",
+                "hazard_type": "CUSTOM_NODE",
+                "intensity": 0.7,
+                "start_step": 3,
+                "end_step": 4,
+                "firm_ids": [2],
+            }
+        ],
+        lane_shocks=[
+            {
+                "label": "Lane",
+                "links": [[1, 2], [4, 2]],
+                "capacity_fraction": 0.25,
+                "start_step": 5,
+                "end_step": 6,
+            }
+        ],
+        route_shocks=[
+            {
+                "label": "Route",
+                "route_tag": "TEST_ROUTE",
+                "intensity": 0.6,
+                "start_step": 7,
+                "end_step": 8,
+            }
+        ],
+    )
+
+    assert raster_events == [
+        HazardRasterEvent(return_period=5, start_step=1, end_step=2, hazard_type="FL", path=None)
+    ]
+    assert node_events == [
+        NodeShock(
+            label="Node",
+            hazard_type="CUSTOM_NODE",
+            intensity=0.7,
+            start_step=3,
+            end_step=4,
+            firm_ids=(2,),
+        )
+    ]
+    assert lane_events == [
+        LaneShock(
+            label="Lane #1",
+            supplier_id=1,
+            buyer_id=2,
+            capacity_fraction=0.25,
+            start_step=5,
+            end_step=6,
+        ),
+        LaneShock(
+            label="Lane #2",
+            supplier_id=4,
+            buyer_id=2,
+            capacity_fraction=0.25,
+            start_step=5,
+            end_step=6,
+        ),
+    ]
+    assert route_events == [
+        RouteShock(
+            label="Route",
+            route_tag="TEST_ROUTE",
+            intensity=0.6,
+            start_step=7,
+            end_step=8,
+        )
+    ]

--- a/tests/test_shock_api.py
+++ b/tests/test_shock_api.py
@@ -210,3 +210,19 @@ def test_param_input_normalization_expands_lane_link_lists() -> None:
             end_step=8,
         )
     ]
+
+
+def test_route_shock_from_mapping_requires_route_tag_or_bottleneck_id() -> None:
+    try:
+        RouteShock.from_mapping(
+            {
+                "label": "Route",
+                "intensity": 0.4,
+                "start_step": 1,
+                "end_step": 2,
+            }
+        )
+    except ValueError as exc:
+        assert "route_tag or bottleneck_id" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected RouteShock.from_mapping() to reject missing route identifiers")

--- a/tests/test_stock_flow_closure.py
+++ b/tests/test_stock_flow_closure.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import numpy as np
 
-from hazard_utils import parse_hazard_event_specs
-from model import EconomyModel
+from upstream.hazard_utils import parse_hazard_event_specs
+from upstream.model import EconomyModel
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_transport_shocks.py
+++ b/tests/test_transport_shocks.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from upstream import HazardRasterEvent, LaneShock, NodeShock, RouteShock, build_model, run_model
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DAMAGE_FUNCTIONS_PATH = _REPO_ROOT / "data" / "global_flood_depth_damage_functions.xlsx"
+_LAND_BOUNDARIES_PATH = _REPO_ROOT / "data" / "ne_110m_admin_0_countries"
+
+
+def _write_transport_topology(tmp_path: Path, *, route_dependencies: list[str] | None = None) -> str:
+    buyer = {
+        "id": 2,
+        "sector": "manufacturing",
+        "lon": 1.0,
+        "lat": 1.0,
+        "capital": 5.0,
+    }
+    if route_dependencies:
+        buyer["route_dependencies"] = list(route_dependencies)
+
+    topology = {
+        "firms": [
+            {"id": 1, "sector": "commodity", "lon": 0.0, "lat": 0.0, "capital": 5.0},
+            buyer,
+            {"id": 3, "sector": "retail", "lon": 2.0, "lat": 1.0, "capital": 5.0},
+            {"id": 4, "sector": "commodity", "lon": -1.0, "lat": 0.0, "capital": 5.0},
+        ],
+        "edges": [
+            {"src": 1, "dst": 2},
+            {"src": 2, "dst": 3},
+        ],
+    }
+    path = tmp_path / "transport_topology.json"
+    path.write_text(json.dumps(topology))
+    return str(path)
+
+
+def _write_global_raster(path: Path, depth: float) -> str:
+    data = np.full((180, 360), depth, dtype=np.float32)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=360,
+        height=180,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=from_origin(-180.0, 90.0, 1.0, 1.0),
+        nodata=-9999.0,
+    ) as dataset:
+        dataset.write(data, 1)
+    return str(path)
+
+
+def _firm_by_id(model, unique_id: int):
+    return next(firm for firm in model._firms if firm.unique_id == unique_id)
+
+
+def test_lane_shock_throttles_deliveries_without_direct_damage(tmp_path: Path) -> None:
+    topology_path = _write_transport_topology(tmp_path)
+    model = build_model(
+        num_households=20,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=False,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=5,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+        lane_shocks=[
+            LaneShock(
+                label="Lane",
+                supplier_id=1,
+                buyer_id=2,
+                capacity_fraction=0.3,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+    )
+
+    supplier = _firm_by_id(model, 1)
+    buyer = _firm_by_id(model, 2)
+    supplier.inventory_output = 20.0
+    supplier.price = 2.0
+
+    patches = model._apply_transport_patches(model._active_transport_blocks(1))
+    try:
+        delivered = supplier.sell_goods_to_firm(buyer, quantity=10.0)
+    finally:
+        model._remove_transport_patches(patches)
+
+    assert delivered == pytest.approx(3.0)
+    assert supplier.raw_direct_loss_fraction_this_step == 0.0
+    assert buyer.raw_direct_loss_fraction_this_step == 0.0
+
+    _, results_df, _ = run_model(
+        steps=1,
+        num_households=20,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=False,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=5,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+        lane_shocks=[
+            LaneShock(
+                label="Lane",
+                supplier_id=1,
+                buyer_id=2,
+                capacity_fraction=0.3,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+    )
+
+    assert results_df["Average_Realized_Direct_Loss"].iloc[0] == 0.0
+    assert results_df["Flooded_Firms"].iloc[0] == 0
+
+
+def test_route_shock_resolves_pairs_from_route_dependencies(tmp_path: Path) -> None:
+    topology_path = _write_transport_topology(tmp_path, route_dependencies=["TEST_ROUTE"])
+    model = build_model(
+        num_households=20,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=False,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=7,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+        route_shocks=[
+            RouteShock(
+                label="Route",
+                route_tag="TEST_ROUTE",
+                intensity=0.4,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+    )
+
+    shock, pairs = model._precomputed_route_transport_edges[0]
+
+    assert shock.route_tag == "TEST_ROUTE"
+    assert [(supplier.unique_id, buyer.unique_id) for supplier, buyer in pairs] == [(1, 2)]
+
+
+def test_mixed_raster_node_and_route_shocks_run_together(tmp_path: Path) -> None:
+    topology_path = _write_transport_topology(tmp_path, route_dependencies=["TEST_ROUTE"])
+    raster_path = _write_global_raster(tmp_path / "global_depth.tif", depth=2.0)
+
+    model, results_df, _ = run_model(
+        steps=2,
+        num_households=20,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=True,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=11,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+        raster_hazard_events=[
+            HazardRasterEvent(
+                return_period=1,
+                start_step=1,
+                end_step=1,
+                hazard_type="FL",
+                path=raster_path,
+            )
+        ],
+        node_shocks=[
+            NodeShock(
+                label="Node",
+                hazard_type="CUSTOM_NODE",
+                intensity=0.5,
+                start_step=1,
+                end_step=1,
+                firm_ids=(1,),
+            )
+        ],
+        route_shocks=[
+            RouteShock(
+                label="Route",
+                route_tag="TEST_ROUTE",
+                intensity=0.5,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+    )
+
+    metadata = model.effective_configuration_metadata()
+
+    assert metadata["RasterHazardEventCount"] == 1
+    assert metadata["NodeShockCount"] == 1
+    assert metadata["RouteShockCount"] == 1
+    assert "Average_Direct_Route_Exposure" in results_df.columns
+    assert "Average_Realized_Direct_Loss" in results_df.columns
+    assert float(results_df["Flooded_Firms"].max()) > 0.0
+    assert float(results_df["Average_Realized_Direct_Loss"].max()) > 0.0

--- a/tests/test_transport_shocks.py
+++ b/tests/test_transport_shocks.py
@@ -16,9 +16,15 @@ _DAMAGE_FUNCTIONS_PATH = _REPO_ROOT / "data" / "global_flood_depth_damage_functi
 _LAND_BOUNDARIES_PATH = _REPO_ROOT / "data" / "ne_110m_admin_0_countries"
 
 
-def _write_transport_topology(tmp_path: Path, *, route_dependencies: list[str] | None = None) -> str:
+def _write_transport_topology(
+    tmp_path: Path,
+    *,
+    route_dependencies: list[str] | None = None,
+    firm_ids: tuple[int, int, int, int] = (1, 2, 3, 4),
+) -> str:
+    commodity_a, buyer_id, retail_id, commodity_b = firm_ids
     buyer = {
-        "id": 2,
+        "id": buyer_id,
         "sector": "manufacturing",
         "lon": 1.0,
         "lat": 1.0,
@@ -29,14 +35,14 @@ def _write_transport_topology(tmp_path: Path, *, route_dependencies: list[str] |
 
     topology = {
         "firms": [
-            {"id": 1, "sector": "commodity", "lon": 0.0, "lat": 0.0, "capital": 5.0},
+            {"id": commodity_a, "sector": "commodity", "lon": 0.0, "lat": 0.0, "capital": 5.0},
             buyer,
-            {"id": 3, "sector": "retail", "lon": 2.0, "lat": 1.0, "capital": 5.0},
-            {"id": 4, "sector": "commodity", "lon": -1.0, "lat": 0.0, "capital": 5.0},
+            {"id": retail_id, "sector": "retail", "lon": 2.0, "lat": 1.0, "capital": 5.0},
+            {"id": commodity_b, "sector": "commodity", "lon": -1.0, "lat": 0.0, "capital": 5.0},
         ],
         "edges": [
-            {"src": 1, "dst": 2},
-            {"src": 2, "dst": 3},
+            {"src": commodity_a, "dst": buyer_id},
+            {"src": buyer_id, "dst": retail_id},
         ],
     }
     path = tmp_path / "transport_topology.json"
@@ -211,3 +217,73 @@ def test_mixed_raster_node_and_route_shocks_run_together(tmp_path: Path) -> None
     assert "Average_Realized_Direct_Loss" in results_df.columns
     assert float(results_df["Flooded_Firms"].max()) > 0.0
     assert float(results_df["Average_Realized_Direct_Loss"].max()) > 0.0
+
+
+def test_shocks_resolve_nonsequential_topology_ids(tmp_path: Path) -> None:
+    topology_path = _write_transport_topology(
+        tmp_path,
+        route_dependencies=["TEST_ROUTE"],
+        firm_ids=(10, 20, 30, 40),
+    )
+    model = build_model(
+        num_households=20,
+        firm_topology_path=topology_path,
+        apply_hazard_impacts=False,
+        adaptation_params={"enabled": False},
+        consumption_ratios={"retail": 1.0},
+        seed=13,
+        damage_functions_path=str(_DAMAGE_FUNCTIONS_PATH),
+        land_boundaries_path=str(_LAND_BOUNDARIES_PATH),
+        node_shocks=[
+            NodeShock(
+                label="Node",
+                hazard_type="CUSTOM_NODE",
+                intensity=0.5,
+                start_step=1,
+                end_step=1,
+                firm_ids=(10,),
+            )
+        ],
+        lane_shocks=[
+            LaneShock(
+                label="Lane",
+                supplier_id=10,
+                buyer_id=20,
+                capacity_fraction=0.4,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+        route_shocks=[
+            RouteShock(
+                label="Route",
+                route_tag="TEST_ROUTE",
+                intensity=0.3,
+                start_step=1,
+                end_step=1,
+            )
+        ],
+    )
+
+    supplier = model._topology_id_to_agent[10]
+    buyer = model._topology_id_to_agent[20]
+
+    assert supplier.unique_id != 10
+    assert buyer.unique_id != 20
+
+    lane_pairs = model._precomputed_lane_transport_edges[0][1]
+    route_pairs = model._precomputed_route_transport_edges[0][1]
+
+    assert [
+        (getattr(src, "topology_id", src.unique_id), getattr(dst, "topology_id", dst.unique_id))
+        for src, dst in lane_pairs
+    ] == [(10, 20)]
+    assert [
+        (getattr(src, "topology_id", src.unique_id), getattr(dst, "topology_id", dst.unique_id))
+        for src, dst in route_pairs
+    ] == [(10, 20)]
+
+    x, y = supplier.pos
+    lon = float(model.lon_vals[x])
+    lat = float(model.lat_vals[y])
+    assert model.hazards["CUSTOM_NODE"].sample_at_coords([(lon, lat)], 0)[0] > 0.0

--- a/transport_runtime.py
+++ b/transport_runtime.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+
+def dedupe_pairs(pairs: List[Tuple[object, object]]) -> List[Tuple[object, object]]:
+    seen: set[tuple[int, int]] = set()
+    deduped: List[Tuple[object, object]] = []
+    for supplier, buyer in pairs:
+        key = (
+            getattr(supplier, "unique_id", id(supplier)),
+            getattr(buyer, "unique_id", id(buyer)),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((supplier, buyer))
+    return deduped
+
+
+def make_transport_patch(supplier_firm, original_sell, blocked_buyers: dict):
+    def patched_sell(buying_firm, quantity=1.0, *, unit_price=None, reservation_buyer_id=None):
+        requested_qty = max(0.0, float(quantity))
+        price = getattr(supplier_firm, "price", 0.0) if unit_price is None else max(0.0, float(unit_price))
+        attempted_revenue = requested_qty * price
+
+        supplier_firm.route_sales_attempted_this_step += requested_qty
+        supplier_firm.route_revenue_attempted_this_step += attempted_revenue
+
+        buying_firm.inbound_route_sales_attempted_this_step = (
+            getattr(buying_firm, "inbound_route_sales_attempted_this_step", 0.0)
+            + requested_qty
+        )
+        buying_firm.inbound_route_revenue_attempted_this_step = (
+            getattr(buying_firm, "inbound_route_revenue_attempted_this_step", 0.0)
+            + attempted_revenue
+        )
+
+        bid = buying_firm.unique_id
+        if bid in blocked_buyers:
+            blocked_fraction = max(0.0, min(1.0, float(blocked_buyers[bid])))
+            blocked_qty = requested_qty * blocked_fraction
+            blocked_revenue = blocked_qty * price
+            supplier_firm.route_sales_blocked_this_step += blocked_qty
+            supplier_firm.route_revenue_blocked_this_step += blocked_revenue
+            buying_firm.inbound_route_sales_blocked_this_step = (
+                getattr(buying_firm, "inbound_route_sales_blocked_this_step", 0.0)
+                + blocked_qty
+            )
+            buying_firm.inbound_route_revenue_blocked_this_step = (
+                getattr(buying_firm, "inbound_route_revenue_blocked_this_step", 0.0)
+                + blocked_revenue
+            )
+            scaled_qty = requested_qty * (1.0 - blocked_fraction)
+            result = original_sell(
+                buying_firm,
+                scaled_qty,
+                unit_price=unit_price,
+                reservation_buyer_id=reservation_buyer_id,
+            )
+            supplier_firm.raw_supplier_disruption_this_step = max(
+                supplier_firm.raw_supplier_disruption_this_step,
+                blocked_fraction,
+            )
+            return result
+
+        return original_sell(
+            buying_firm,
+            requested_qty,
+            unit_price=unit_price,
+            reservation_buyer_id=reservation_buyer_id,
+        )
+
+    return patched_sell
+
+
+def route_exposure_ratio(firm) -> float:
+    attempted = max(0.0, float(getattr(firm, "route_revenue_attempted_this_step", 0.0)))
+    blocked = max(0.0, float(getattr(firm, "route_revenue_blocked_this_step", 0.0)))
+    if attempted <= 1e-9:
+        return 0.0
+    return min(1.0, blocked / attempted)
+
+
+def inbound_route_exposure_ratio(firm) -> float:
+    attempted = max(0.0, float(getattr(firm, "inbound_route_revenue_attempted_this_step", 0.0)))
+    blocked = max(0.0, float(getattr(firm, "inbound_route_revenue_blocked_this_step", 0.0)))
+    if attempted <= 1e-9:
+        return 0.0
+    return min(1.0, blocked / attempted)

--- a/transport_runtime.py
+++ b/transport_runtime.py
@@ -58,10 +58,10 @@ def make_transport_patch(supplier_firm, original_sell, blocked_buyers: dict):
                 unit_price=unit_price,
                 reservation_buyer_id=reservation_buyer_id,
             )
-            supplier_firm.raw_supplier_disruption_this_step = max(
-                supplier_firm.raw_supplier_disruption_this_step,
-                blocked_fraction,
-            )
+            # Keep pair-specific transport attribution on the buyer via the
+            # inbound blocked counters above. Seller-side route metrics still
+            # capture lost sales directly, but blocked lanes should not mark
+            # the supplier as having an upstream input shortage.
             return result
 
         return original_sell(


### PR DESCRIPTION
Supports first-class external shock APIs so callers do not need wrapper-owned monkeypatches to model transport disruption